### PR TITLE
fix network fetch when defined by name

### DIFF
--- a/pkg/nutanix/machine-config/nutanix.vue
+++ b/pkg/nutanix/machine-config/nutanix.vue
@@ -113,7 +113,7 @@ export default {
     this.vmImage.selected = this.vmImage.options.find((o) => o.value.name === this.value.vmImage)?.value;
     this.vmImageSize.selected = this.value.vmImageSize;
 
-    this.networks.selected = this.value.vmNetwork.map(e => this.networks.baseOption.find((o) => o.value.extId === e || o.extId === e));
+    this.networks.selected = this.value.vmNetwork.map(e => this.networks.baseOption.find((o) => o.value.extId === e || o.extId === e || o.label === e));
     this.filterNetworks();
     this.bootType = this.value.bootType === "legacy" ? "Legacy" : "UEFI";
     this.vmCategories.selected = this.value.vmCategories.map(e => this.vmCategories.options.find((o) => o.name === e || o.value?.name === e));


### PR DESCRIPTION
The default format for the extension is to store the network using its UUID. However, there are cases where the network can be defined by its name,(due to manual creation or in older versions of the driver/extension).

This change enables the correct display of the network name in both edit and view modes when the network is defined by its name.