### PR TITLE
Fix/missing cluster reference list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nutanix",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "engines": {
     "node": ">=20.0.0"
   },

--- a/pkg/nutanix/nutanix.ts
+++ b/pkg/nutanix/nutanix.ts
@@ -113,7 +113,7 @@ export class Nutanix {
       filter: (network: any) =>
         (network.subnetType == "OVERLAY" ||
           network.clusterReference == this.clusterReferenceId ||
-          network?.clusterReferenceList.includes(this.clusterReferenceId)) && !network.isExternal,
+          network?.clusterReferenceList?.includes(this.clusterReferenceId)) && !network.isExternal,
       initial
     });
   }

--- a/pkg/nutanix/package.json
+++ b/pkg/nutanix/package.json
@@ -2,7 +2,7 @@
   "name": "nutanix",
   "description": "Nutanix UI Extension provides a seamless interface for configuring Rancher clusters on Nutanix Cloud Platform",
   "icon": "https://raw.githubusercontent.com/nutanix-cloud-native/nutanix-rancher-extension/main/pkg/nutanix/assets/icon-nutanix.svg",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "private": false,
   "rancher": {
     "annotations": {


### PR DESCRIPTION
This pull request includes a minor version bump to `1.2.1` for both the root and package-level `package.json` files, and a small fix in the `Nutanix` class to handle cases where `clusterReferenceList` might be undefined for network created with old Nutanix version.

Version updates:

* Bumped the version from `1.2.0` to `1.2.1` in both the root `package.json` and `pkg/nutanix/package.json` to reflect the new release. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-50eaf262970858380f36b2baaf15459fc800304c9192354719db625f76564552L5-R5)

Bug fix:

* Updated the filter logic in the `Nutanix` class (`pkg/nutanix/nutanix.ts`) to safely handle cases where `clusterReferenceList` may be undefined by using optional chaining (`?.includes`).

fix #33 